### PR TITLE
Temporarily remove access token from requirement

### DIFF
--- a/config.ru
+++ b/config.ru
@@ -1,3 +1,4 @@
+$stdout.sync = true
 ENV['RACK_ENV'] ||= 'development'
 require './bootstrap.rb'
 

--- a/stations_bot.rb
+++ b/stations_bot.rb
@@ -26,7 +26,7 @@ module StationsBot
 
     helpers do
       def authenticate
-        Team.where(team_id: params['team_id'], access_token: params['token']).any?
+        Team.where(team_id: params['team_id']).any?
       end
 
       def args


### PR DESCRIPTION
The token provided in the oauth process is different than the access token sent with each Slack request. This temporarily removes it until we have more time to research.
